### PR TITLE
add sha-bang bash for script, because it fail on zsh

### DIFF
--- a/pacman.sh
+++ b/pacman.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 set -o nounset
 


### PR DESCRIPTION
add sha-bang bash for script, because it fail on zsh
